### PR TITLE
add Jenkinsfile and Dockerfile for corresponding agent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
+# not recommended but simple enough for a demo
+add_definitions(-DMASTER_TEST_SUITE_NAME="${CMAKE_CXX_COMPILER}/${CMAKE_BUILD_TYPE}")
+
 add_subdirectory(bluetoe)
 add_subdirectory(tests)
 add_subdirectory(examples)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM jenkins/jnlp-slave
+
+USER root
+
+RUN apt update && \
+    apt install --assume-yes cmake build-essential libboost-all-dev clang ninja-build
+
+USER jenkins

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,104 @@
+#!/usr/bin/env groovy
+// @Library('github.com/obruns/bluetoe@topic/add-jenkinsfile') _
+// https://jenkins.io/doc/pipeline/steps/
+// https://jenkins.io/doc/pipeline/steps/xunit/#xunit-publish-xunit-test-result-report
+
+buildMatrix [
+ ['compiler': 'g++', 'mode': 'Debug', 'label': 'linux'],
+ ['compiler': 'g++', 'mode': 'Release', 'label': 'linux'],
+ ['compiler': 'clang++', 'mode': 'Debug', 'label': 'linux'],
+ ['compiler': 'clang++', 'mode': 'Release', 'label': 'linux'],
+// ['mode': 'Debug', 'label': 'windows']  // script defaults to compiler msvc
+]
+
+def buildMatrix(List matrix) {
+pipeline {
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '100')) // 100 - Rotation only for test
+    timestamps()
+  }
+
+  agent none
+
+  environment {
+    BUILD_DIR = "build"
+  }
+
+  stages {
+    stage ("Parallel: Build and Test") {
+      steps {
+        script {
+          def parameterized_stages = [:]
+
+          def bMatrix = matrix
+
+          for (x in bMatrix) {
+            def compiler = x['compiler']
+            def config = x['mode']
+            def CONFIG = "${config}"
+
+            parameterized_stages["${compiler}/${config}"] =  {
+
+              stage("${compiler}/${config}") {
+                node ('c++') {
+                  try {
+                    stage('Checkout') {
+                        script {
+                            checkout scm
+                        }
+                    }
+                    stage('Cleanup') {
+                        script {
+                            sh "rm -rf ${BUILD_DIR}_${CONFIG}"
+                        }
+                    }
+                    stage('Run CMake') {
+                      environment {
+                        GENERATOR = "Ninja"
+                      }
+                        dir("${BUILD_DIR}_${CONFIG}") {
+                          sh """
+                            cmake ${WORKSPACE} \
+                                  -G Ninja \
+                                  -DBLUETOE_EXCLUDE_SLOW_TESTS=1 \
+                                  -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE \
+                                  -DCMAKE_BUILD_TYPE=${CONFIG} \
+                                  -DCMAKE_CXX_COMPILER=${compiler}
+                          """
+                        }
+                    }
+                    stage('Build and Link') {
+                      environment {
+                        NINJA_STATUS = "[%r %c %o %e (%s/%t)]"
+                      }
+                        sh """
+                          cmake --build ${WORKSPACE}/${BUILD_DIR}_${CONFIG} \
+                                --config ${CONFIG} \
+                                -- -j 1 -k 100 -v -d explain
+                        """
+                    }
+                    stage('Run Boost Tests') {
+                        dir("${BUILD_DIR}_${CONFIG}") {
+                            sh "ctest --verbose"
+                        }
+                    }
+                  }
+                  // https://stackoverflow.com/questions/48989238/post-equivalent-in-scripted-pipeline
+                  finally {  // post { always { } }
+                    // https://stackoverflow.com/questions/45133596/how-do-i-publish-boost-unit-tests-with-jenkins-pipeline-and-xunit-plugin
+                    // https://stackoverflow.com/questions/16537914/using-jenkins-with-boost-test-unit-tests
+                    // https://github.com/jenkinsci/xunit-plugin/tree/master/src/main/java/org/jenkinsci/plugins/xunit/types
+                    step([$class: 'XUnitBuilder', tools: [[$class: 'BoostTestJunitHudsonTestType', pattern: "${BUILD_DIR}_${CONFIG}/tests/*.xml"]]])
+                    deleteDir()
+                  }
+                }
+              }
+            }
+          }
+          parallel parameterized_stages
+        }
+      }
+    }
+  }
+}
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ function(add_and_register_test TARGETNAME)
     add_executable(${TARGETNAME} ${TARGETNAME}.cpp ${ARGV1} ${ARGV2} ${ARGV3} ${ARGV4})
     target_link_libraries(${TARGETNAME} bluetoe test_tools)
     add_test(${TARGETNAME} ${TARGETNAME})
+    set_tests_properties(${TARGETNAME} PROPERTIES ENVIRONMENT "BOOST_TEST_LOGGER=XML,unit_scope,${TARGETNAME}.xml")
 endfunction()
 
 if (BLUETOE_EXCLUDE_SLOW_TESTS)

--- a/tests/advertising_tests.cpp
+++ b/tests/advertising_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include <bluetoe/adv_service_list.hpp>

--- a/tests/att/execute_write_tests.cpp
+++ b/tests/att/execute_write_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/att/find_by_type_value_tests.cpp
+++ b/tests/att/find_by_type_value_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/att/find_information_tests.cpp
+++ b/tests/att/find_information_tests.cpp
@@ -1,5 +1,5 @@
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/att/find_notification_data_tests.cpp
+++ b/tests/att/find_notification_data_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include <bluetoe/server.hpp>

--- a/tests/att/indication_tests.cpp
+++ b/tests/att/indication_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include <bluetoe/server.hpp>

--- a/tests/att/mtu_exchange_tests.cpp
+++ b/tests/att/mtu_exchange_tests.cpp
@@ -1,5 +1,5 @@
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/att/notification_tests.cpp
+++ b/tests/att/notification_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include <bluetoe/link_layer/notification_queue.hpp>

--- a/tests/att/outgoing_priority_tests.cpp
+++ b/tests/att/outgoing_priority_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include <bluetoe/server.hpp>

--- a/tests/att/prepare_write_tests.cpp
+++ b/tests/att/prepare_write_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/att/read_blob_tests.cpp
+++ b/tests/att/read_blob_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/att/read_by_group_type_tests.cpp
+++ b/tests/att/read_by_group_type_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/att/read_by_type_tests.cpp
+++ b/tests/att/read_by_type_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/att/read_multiple_tests.cpp
+++ b/tests/att/read_multiple_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/att/read_tests.cpp
+++ b/tests/att/read_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/att/request_not_supported_tests.cpp
+++ b/tests/att/request_not_supported_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/att/write_command_tests.cpp
+++ b/tests/att/write_command_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/att/write_tests.cpp
+++ b/tests/att/write_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/auto_uuid_tests.cpp
+++ b/tests/auto_uuid_tests.cpp
@@ -2,7 +2,7 @@
 #include <array>
 #include <bluetoe/service.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_attribute_access.hpp"

--- a/tests/characteristic_tests.cpp
+++ b/tests/characteristic_tests.cpp
@@ -5,7 +5,7 @@
 #include <bluetoe/service.hpp>
 #include <bluetoe/client_characteristic_configuration.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 #include "hexdump.hpp"
 #include "test_attribute_access.hpp"

--- a/tests/characteristic_value_tests.cpp
+++ b/tests/characteristic_value_tests.cpp
@@ -2,7 +2,7 @@
 #include <bluetoe/service.hpp>
 #include <bluetoe/client_characteristic_configuration.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 #include "hexdump.hpp"
 #include "test_attribute_access.hpp"

--- a/tests/filter_tests.cpp
+++ b/tests/filter_tests.cpp
@@ -4,7 +4,7 @@
 #include <bluetoe/attribute.hpp>
 #include <bluetoe/uuid.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 namespace blued = bluetoe::details;

--- a/tests/gap_service_tests.cpp
+++ b/tests/gap_service_tests.cpp
@@ -1,7 +1,7 @@
 #include <bluetoe/gap_service.hpp>
 #include <bluetoe/server.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_servers.hpp"

--- a/tests/link_layer/address_tests.cpp
+++ b/tests/link_layer/address_tests.cpp
@@ -1,6 +1,6 @@
 #include <bluetoe/link_layer/address.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_CASE( is_default_constructable, bluetoe::link_layer::address )

--- a/tests/link_layer/advertiser_tests.cpp
+++ b/tests/link_layer/advertiser_tests.cpp
@@ -1,6 +1,6 @@
 #include "buffer_io.hpp"
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 #include <boost/mpl/list.hpp>
 

--- a/tests/link_layer/channel_map_tests.cpp
+++ b/tests/link_layer/channel_map_tests.cpp
@@ -1,6 +1,6 @@
 #include <bluetoe/link_layer/channel_map.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 static constexpr std::uint8_t all_channel_map[] = { 0xff, 0xff, 0xff, 0xff, 0x1f };

--- a/tests/link_layer/connection_callbacks_tests.cpp
+++ b/tests/link_layer/connection_callbacks_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include <bluetoe/link_layer/link_layer.hpp>

--- a/tests/link_layer/connection_parameter_update_procedure_tests.cpp
+++ b/tests/link_layer/connection_parameter_update_procedure_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "buffer_io.hpp"

--- a/tests/link_layer/delta_time_tests.cpp
+++ b/tests/link_layer/delta_time_tests.cpp
@@ -1,6 +1,6 @@
 #include <bluetoe/link_layer/delta_time.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 #include <algorithm>
 

--- a/tests/link_layer/ll_advertising_tests.cpp
+++ b/tests/link_layer/ll_advertising_tests.cpp
@@ -1,6 +1,6 @@
 #include "buffer_io.hpp"
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 #include <boost/mpl/list.hpp>
 

--- a/tests/link_layer/ll_connecting_tests.cpp
+++ b/tests/link_layer/ll_connecting_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/test_case_template.hpp>
 

--- a/tests/link_layer/ll_connection_tests.cpp
+++ b/tests/link_layer/ll_connection_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "connected.hpp"

--- a/tests/link_layer/ll_control_tests.cpp
+++ b/tests/link_layer/ll_control_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "connected.hpp"

--- a/tests/link_layer/ll_data_pdu_buffer_tests.cpp
+++ b/tests/link_layer/ll_data_pdu_buffer_tests.cpp
@@ -2,7 +2,7 @@
 #include "buffer_io.hpp"
 #include <bluetoe/link_layer/ll_data_pdu_buffer.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 #include <boost/mpl/list.hpp>
 

--- a/tests/link_layer/ll_data_tests.cpp
+++ b/tests/link_layer/ll_data_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include <bluetoe/link_layer/link_layer.hpp>

--- a/tests/link_layer/notification_queue_tests.cpp
+++ b/tests/link_layer/notification_queue_tests.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <bluetoe/link_layer/notification_queue.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 namespace {

--- a/tests/link_layer/ring_buffer_tests.cpp
+++ b/tests/link_layer/ring_buffer_tests.cpp
@@ -1,6 +1,6 @@
 #include <bluetoe/link_layer/ring_buffer.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 struct small_ring : bluetoe::link_layer::pdu_ring_buffer< 50 >

--- a/tests/link_layer/signaling_channel_tests.cpp
+++ b/tests/link_layer/signaling_channel_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 #include <bluetoe/link_layer/l2cap_signaling_channel.hpp>
 

--- a/tests/link_layer/test_radio_tests.cpp
+++ b/tests/link_layer/test_radio_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_radio.hpp"

--- a/tests/link_layer/white_list_tests.cpp
+++ b/tests/link_layer/white_list_tests.cpp
@@ -1,6 +1,6 @@
 #include <bluetoe/link_layer/white_list.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/test_case_template.hpp>
 #include <boost/mpl/list.hpp>

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -1,7 +1,7 @@
 #include <bluetoe/options.hpp>
 #include <string>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include <type_traits>

--- a/tests/read_write_handler_tests.cpp
+++ b/tests/read_write_handler_tests.cpp
@@ -6,7 +6,7 @@
 #include <bluetoe/service.hpp>
 #include <bluetoe/server.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include <boost/mpl/list.hpp>

--- a/tests/scattered_access_tests.cpp
+++ b/tests/scattered_access_tests.cpp
@@ -2,7 +2,7 @@
 #include <bluetoe/scattered_access.hpp>
 #include "hexdump.hpp"
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 namespace blued = bluetoe::details;

--- a/tests/security_manager/pairing_tests.cpp
+++ b/tests/security_manager/pairing_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include <bluetoe/server.hpp>

--- a/tests/server_tests.cpp
+++ b/tests/server_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 #include "test_servers.hpp"
 

--- a/tests/service_tests.cpp
+++ b/tests/service_tests.cpp
@@ -2,7 +2,7 @@
 #include "test_services.hpp"
 #include "hexdump.hpp"
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include <iterator>

--- a/tests/services/bootloader_tests.cpp
+++ b/tests/services/bootloader_tests.cpp
@@ -7,7 +7,7 @@
 #include <bluetoe/server.hpp>
 #include <bluetoe/services/bootloader.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include "test_gatt.hpp"

--- a/tests/services/cscs_tests.cpp
+++ b/tests/services/cscs_tests.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 #include <bluetoe/services/csc.hpp>

--- a/tests/write_queue_tests.cpp
+++ b/tests/write_queue_tests.cpp
@@ -1,10 +1,12 @@
 #include <iostream>
 #include <bluetoe/write_queue.hpp>
 
-#define BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE MASTER_TEST_SUITE_NAME
 #include <boost/test/included/unit_test.hpp>
 
 namespace blued = bluetoe::details;
+
+BOOST_AUTO_TEST_SUITE( write_queue_tests )
 
 BOOST_FIXTURE_TEST_CASE( empty_write_queue_is_instanceiable, blued::write_queue< blued::no_such_type > )
 {
@@ -123,3 +125,5 @@ BOOST_FIXTURE_TEST_CASE( can_be_freed_and_allocated_again, locked_by_client1 )
     free_write_queue( client1 );
     BOOST_CHECK( allocate_from_write_queue( 15, client2 ) != nullptr );
 }
+
+BOOST_AUTO_TEST_SUITE_END( write_queue_tests )

--- a/vars/tsh.groovy
+++ b/vars/tsh.groovy
@@ -1,0 +1,11 @@
+def call(String args, String interpreter = 'cmd') {
+  if (isUnix) {
+    sh args
+  } else {
+    if (interpreter == 'cmd') {
+      cmd args
+    } else {
+      powershell args
+    }
+  }
+}


### PR DESCRIPTION
Like with .gitlab-ci.yml the amount of duplication is just hilarious.
Think about the following (minimal) starting point:

I want to build with compilers {clang++,g++} in mode {Debug,Release}.
That makes four combinations which is just not acceptable. There has to
be a way to create that permutations and iterate them without
duplication at all.

In addition, I'd clang++ and g++ to be executed on agents of the same
type but never on the same agent in parallel.

  agent {
    node {
      label 'c++'
    }
  }

[1] https://stackoverflow.com/questions/47521940/how-can-i-force-my-jenkinsfile-parallel-steps-to-use-different-agents
[2] https://jenkins.io/blog/2017/09/25/declarative-1/